### PR TITLE
Add global exception handler

### DIFF
--- a/examples/decorator_example.py
+++ b/examples/decorator_example.py
@@ -1,0 +1,48 @@
+from llm_catcher import LLMExceptionDiagnoser
+import asyncio
+import sqlite3
+
+diagnoser = LLMExceptionDiagnoser()
+
+
+@diagnoser.catch
+def risky_function():
+    """This function will raise an error that gets diagnosed."""
+    return 1 / 0
+
+
+@diagnoser.catch
+async def async_risky_function():
+    """This async function will raise an error that gets diagnosed."""
+    import pandas  # noqa: F401, F841
+    return True
+
+
+@diagnoser.catch
+def database_error():
+    """This will raise a sqlite3.OperationalError."""
+    # Try to connect to a database in a non-existent directory
+    conn = sqlite3.connect('/nonexistent/directory/database.db')
+    cursor = conn.cursor()
+    cursor.execute("SELECT * FROM nonexistent_table")
+
+
+async def main():
+    try:
+        risky_function()
+    except Exception as e:  # noqa: B902, F841
+        # don't do anything, the diagnoser will handle it
+        pass
+    try:
+        await async_risky_function()
+    except Exception as e:  # noqa: B902, F841
+        # don't do anything, the diagnoser will handle it
+        pass
+    try:
+        database_error()
+    except Exception as e:  # noqa: B902, F841
+        # don't do anything, the diagnoser will handle it
+        pass
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/minimal_example.py
+++ b/examples/minimal_example.py
@@ -4,13 +4,16 @@ import asyncio
 
 async def main():
     """Demonstrate basic usage of LLM Catcher."""
-    # Initialize diagnoser (will use settings from config.json)
+    # Initialize diagnoser (global handler is enabled by default)
     diagnoser = LLMExceptionDiagnoser()
+
+    # Or explicitly disable the global handler
+    # diagnoser = LLMExceptionDiagnoser(global_handler=False)
 
     try:
         # Cause a simple error
         # Will raise ModuleNotFoundError
-        import nonexistent_package  # noqa: F401
+        potato
     except Exception as e:
         # Get diagnosis from LLM
         diagnosis = await diagnoser.async_diagnose(e)
@@ -23,6 +26,9 @@ async def main():
         # Get diagnosis from LLM
         diagnosis = diagnoser.diagnose(e)
         print(diagnosis)
+
+    # This unhandled exception will be caught by the global handler
+    import pandas  # This will raise an error if numpy isn't installed
 
 
 if __name__ == "__main__":

--- a/examples/minimal_example.py
+++ b/examples/minimal_example.py
@@ -13,7 +13,7 @@ async def main():
     try:
         # Cause a simple error
         # Will raise ModuleNotFoundError
-        potato
+        potato  # noqa: F821
     except Exception as e:
         # Get diagnosis from LLM
         diagnosis = await diagnoser.async_diagnose(e)
@@ -28,7 +28,7 @@ async def main():
         print(diagnosis)
 
     # This unhandled exception will be caught by the global handler
-    import pandas  # This will raise an error if numpy isn't installed
+    import pandas  # noqa: F401, F841
 
 
 if __name__ == "__main__":

--- a/llm_catcher/diagnoser.py
+++ b/llm_catcher/diagnoser.py
@@ -6,7 +6,7 @@ import traceback
 import os
 import sys
 from functools import wraps
-from typing import Callable, TypeVar, ParamSpec, Any
+from typing import Callable, TypeVar, ParamSpec
 import asyncio
 
 P = ParamSpec('P')

--- a/llm_catcher/diagnoser.py
+++ b/llm_catcher/diagnoser.py
@@ -209,7 +209,6 @@ class LLMExceptionDiagnoser:
                 return func(*args, **kwargs)
             except Exception as e:
                 diagnosis = self.diagnose(e)
-                # print("\nLLM Diagnosis:", file=sys.stderr)
                 print(diagnosis, file=sys.stderr)
                 raise  # Re-raise the exception after diagnosis
 
@@ -219,33 +218,7 @@ class LLMExceptionDiagnoser:
                 return await func(*args, **kwargs)
             except Exception as e:
                 diagnosis = await self.async_diagnose(e)
-                # print("\nLLM Diagnosis:", file=sys.stderr)
                 print(diagnosis, file=sys.stderr)
                 raise  # Re-raise the exception after diagnosis
 
         return async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper
-
-    def fastapi_catch(self, func: Callable[P, T]) -> Callable[P, T]:
-        """Decorator specifically for FastAPI endpoints.
-
-        Example:
-            @app.get("/my-endpoint")
-            @diagnoser.fastapi_catch
-            async def my_endpoint():
-                # Errors will be diagnosed and returned as HTTP responses
-                result = 1 / 0
-        """
-        @wraps(func)
-        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
-            try:
-                return await func(*args, **kwargs)
-            except Exception as e:
-                diagnosis = await self.async_diagnose(e, formatted=False)
-                raise HTTPException(
-                    status_code=500,
-                    detail={
-                        "error": str(e),
-                        "diagnosis": diagnosis
-                    }
-                )
-        return wrapper

--- a/llm_catcher/diagnoser.py
+++ b/llm_catcher/diagnoser.py
@@ -8,7 +8,6 @@ import sys
 from functools import wraps
 from typing import Callable, TypeVar, ParamSpec, Any
 import asyncio
-from fastapi import HTTPException
 
 P = ParamSpec('P')
 T = TypeVar('T')


### PR DESCRIPTION
based on a suggestion from Reddit user https://www.reddit.com/user/No_Dig_7017/
- added a global exception hook to better catch unhandled exceptions from imported modules
- added the ability to turn that global handler off
- added a decorator usage pattern
- added additional examples for using the decorator
- updated readme to remove caveats and reorganized the sections and added more usage patterns
- added a note about active development and breaking changes 
- fixed a bug where output from the LLM was being cut off by the formatting 
